### PR TITLE
Yash/fix erc721 extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-icons": "^5.2.1",
-    "thirdweb": "^5.28.0"
+    "thirdweb": "5.71.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/extensions/getOwnedERC721s.ts
+++ b/src/extensions/getOwnedERC721s.ts
@@ -34,23 +34,10 @@ export async function getOwnedERC721s(
 	options: BaseTransactionOptions<GetERC721sParams>,
 ): Promise<NFT[]> {
 	const { contract, owner, requestPerSec } = options;
-
-	const [is721, has_tokenOfOwnerByIndex] = await Promise.all([
-		isERC721({ contract }),
-		detectMethod({
-			method:
-				"function tokenOfOwnerByIndex(address owner, uint256 index) external view returns (uint256)",
-			contract,
-		}),
-	]);
+    const is721 = await isERC721({ contract });
 
 	if (!is721) {
 		throw new Error("Contract is not an ERC721 contract");
-	}
-
-	if (has_tokenOfOwnerByIndex) {
-		const { getOwnedNFTs } = await import("thirdweb/extensions/erc721");
-		return getOwnedNFTs(options);
 	}
 
 	const { nextTokenIdToMint, startTokenId, totalSupply, ownerOf, getNFT } =


### PR DESCRIPTION
- Update to the latest version of the SDK.
- Remove the check for hasTokenOfOwnerByIndex to fix the getOwnedERC721s extension.